### PR TITLE
fine-grained Personal Access Token 利用時の GitHub API エラーを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TAG := $(shell git describe --tags --always --dirty)
-IMAGE ?= ghcr.io/pfnet-research/alertmanager-to-github:$(TAG)
+IMAGE ?= ghcr.io/cuteip/alertmanager-to-github:$(TAG)
 ARCH ?= amd64
 ALL_ARCH ?= amd64 arm64
 

--- a/pkg/notifier/github.go
+++ b/pkg/notifier/github.go
@@ -106,7 +106,7 @@ func (n *GitHubNotifier) Notify(ctx context.Context, payload *types.WebhookPaylo
 		return err
 	}
 
-	query := fmt.Sprintf(`repo:%s/%s "%s"`, owner, repo, alertID)
+	query := fmt.Sprintf(`is:issue repo:%s/%s "%s"`, owner, repo, alertID)
 	searchResult, response, err := n.GitHubClient.Search.Issues(ctx, query, &github.SearchOptions{
 		TextMatch: true,
 	})


### PR DESCRIPTION
## 背景

[fine-grained Personal Access Token](https://github.blog/2022-10-18-introducing-fine-grained-personal-access-tokens-for-github/) を利用すると、`GET https://api.github.com/search/issues` にてエラーになってしまう。エラーメッセージは「422 Query must include 'is:issue' or 'is:pull-request'」だった。
https://docs.github.com/en/rest/search?apiVersion=2022-11-28#search-issues-and-pull-requests には、Issue と PR の両方を同時に検索できないことが説明されている。

## 概要

fine-grained Personal Access Token 利用時に前述のエラーが発生しないようにした。
