### PR TITLE
Webhook Payload に `fingerprint` を追加

### DIFF
--- a/pkg/types/payload.go
+++ b/pkg/types/payload.go
@@ -32,6 +32,7 @@ type WebhookAlert struct {
 	StartsAt     time.Time         `json:"startsAt"`
 	EndsAt       time.Time         `json:"endsAt"`
 	GeneratorURL string            `json:"generatorURL"`
+	Fingerprint  string            `json:"fingerprint"`
 }
 
 func (p *WebhookPayload) LabelKeysExceptCommon() []string {


### PR DESCRIPTION
https://prometheus.io/docs/alerting/latest/configuration/#webhook_config にて `fingerprint` が定義されていたものの、実装には存在していなかった。この PR で追加する。