### PR TITLE
ライセンス表記に「CuteIP」を追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -188,6 +188,7 @@
       identification within third-party archives.
 
    Copyright 2020 Preferred Networks, Inc.
+   Copyright 2023 CuteIP
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fork していくつか変更を加えているので、ライセンス表記に「CuteIP」を追加した。

これを参考にした。
[GitHubのforkとライセンス | アプリNaviブログ](https://blog.opuappnavi.com/post/github-fork-mit/)