### PR TITLE
リリースのファイル名にバージョンを含める

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,6 +13,7 @@ archives:
   - format: tar.gz
     name_template: >-
       {{ .ProjectName }}_
+      {{- .Tag }}_
       {{- .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386


### PR DESCRIPTION
リリースに置かれる `.tar.gz` などのファイル名にバージョンを含めるようにした。

`v` を含めるかどうかはどっちが良いのかわからないが、とりあえず含めることにした。

```
$ goreleaser release --snapshot --clean

$ tree ./dist
./dist
├── alertmanager-to-github_darwin_amd64_v1
│   └── alertmanager-to-github
├── alertmanager-to-github_darwin_arm64
│   └── alertmanager-to-github
├── alertmanager-to-github_linux_386
│   └── alertmanager-to-github
├── alertmanager-to-github_linux_amd64_v1
│   └── alertmanager-to-github
├── alertmanager-to-github_linux_arm64
│   └── alertmanager-to-github
├── alertmanager-to-github_v0.0.2_darwin_arm64.tar.gz
├── alertmanager-to-github_v0.0.2_darwin_x86_64.tar.gz
├── alertmanager-to-github_v0.0.2_linux_arm64.tar.gz
├── alertmanager-to-github_v0.0.2_linux_i386.tar.gz
├── alertmanager-to-github_v0.0.2_linux_x86_64.tar.gz
├── alertmanager-to-github_v0.0.2_windows_arm64.zip
├── alertmanager-to-github_v0.0.2_windows_i386.zip
├── alertmanager-to-github_v0.0.2_windows_x86_64.zip
├── alertmanager-to-github_windows_386
│   └── alertmanager-to-github.exe
├── alertmanager-to-github_windows_amd64_v1
│   └── alertmanager-to-github.exe
├── alertmanager-to-github_windows_arm64
│   └── alertmanager-to-github.exe
├── artifacts.json
├── checksums.txt
├── config.yaml
└── metadata.json

8 directories, 20 files

```