### PR TITLE
Issue を新規作成するオプションを追加

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -34,6 +34,7 @@ const flagAutoCloseResolvedIssues = "auto-close-resolved-issues"
 const flagGitHubAppPrivateKeyFile = "github-app-private-key-file"
 const flagGitHubAppAppID = "github-app-app-id"
 const flagGitHubAppInstallationID = "github-app-installation-id"
+const flagNewIssues = "new-issues"
 
 const defaultPayload = `{
   "version": "4",
@@ -179,6 +180,12 @@ func App() *cli.App {
 						Name:    flagGitHubAppInstallationID,
 						Usage:   fmt.Sprintf("GitHub App's installation id (required if %s)", flagGitHubAppPrivateKeyFile),
 						EnvVars: []string{"ATG_GITHUB_APP_INSTALLATION_ID"},
+					},
+					&cli.BoolFlag{
+						Name:    flagNewIssues,
+						Value:   false,
+						Usage:   "if false, reopen issues when fired and already exsits 'alertID' issue. if true, create 'new' issue.",
+						EnvVars: []string{"ATG_NEW_ISSUES"},
 					},
 				},
 			},
@@ -339,6 +346,7 @@ func actionStart(c *cli.Context) error {
 	nt.TitleTemplate = titleTemplate
 	nt.AlertIDTemplate = alertIDTemplate
 	nt.AutoCloseResolvedIssues = c.Bool(flagAutoCloseResolvedIssues)
+	nt.NewIssues = c.Bool(flagNewIssues)
 
 	router := server.New(nt).Router()
 	if err := router.Run(c.String(flagListen)); err != nil {

--- a/pkg/notifier/github.go
+++ b/pkg/notifier/github.go
@@ -66,6 +66,7 @@ type GitHubNotifier struct {
 	Labels                  []string
 	KeepLabels              []string
 	AutoCloseResolvedIssues bool
+	NewIssues               bool
 }
 
 func NewGitHub() (*GitHubNotifier, error) {
@@ -126,6 +127,9 @@ func (n *GitHubNotifier) Notify(ctx context.Context, payload *types.WebhookPaylo
 	}
 
 	query := fmt.Sprintf(`is:issue repo:%s/%s "%s"`, owner, repo, alertID)
+	if n.NewIssues {
+		query += " is:open"
+	}
 	searchResult, response, err := n.GitHubClient.Search.Issues(ctx, query, &github.SearchOptions{
 		TextMatch: true,
 	})
@@ -239,6 +243,9 @@ func (n *GitHubNotifier) Notify(ctx context.Context, payload *types.WebhookPaylo
 
 func (n *GitHubNotifier) cleanupIssues(ctx context.Context, owner, repo, alertID string) error {
 	query := fmt.Sprintf(`is:issue repo:%s/%s "%s"`, owner, repo, alertID)
+	if n.NewIssues {
+		query += " is:open"
+	}
 	searchResult, response, err := n.GitHubClient.Search.Issues(ctx, query, &github.SearchOptions{
 		TextMatch: true,
 	})


### PR DESCRIPTION
Close #18 

Alertmanager 側の Webhook Payload がうまくわかっていないが、すべてのアラートが一旦無くなってから、5 分ぐらいおいてアラートを再発させたら、新規作成された Issue に、前まで（5 分ぐらい前まで）発生していたアラートの resolved 状態のも Webhook の payload に含まれていた。
言い換えると、Issue が作成される時刻以前かつ resolved 状態のアラートが firing 状態のものと一緒に Issue に含まれてしまった。
ちょっとうまく実装できていない気もするが、とりあえず無視する。